### PR TITLE
Make installation no-interactive

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -8,5 +8,6 @@ These are the contributors to fog05 according to the Github repository.
  GHsername        Name
  ===============  ==================================
  gabrik           Gabriele Baldoni (ADLINK)
+ gabrielepmattia  Gabriele Proietti Mattia
  ===============  ==================================
 

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,6 @@ clean:
 
 
 install:
-	opam install . --working-dir
+	opam install . --working-dir -y
 uninstall:
 	opam remove fos-sdk


### PR DESCRIPTION
Making the installation no interactive is useful for auto-building with Travis CI.