### PR TITLE
Blocking run of FDU, getting Log, file listing and file content

### DIFF
--- a/fos-sdk/yaks_connector.ml
+++ b/fos-sdk/yaks_connector.ml
@@ -1449,7 +1449,7 @@ module MakeGAD(P: sig val prefix: string end) = struct
     MVar.guarded connector @@ fun connector ->
     let p = get_fdu_run_eval_path sysid tenantid nodeid fduid instanceid in
     let cb _ _ =
-      let%lwt r = func in
+      let%lwt r = func () in
       Lwt.return @@ Yaks.Value.StringValue r
     in
     let%lwt _ = Yaks.Workspace.register_eval p cb connector.ws in
@@ -1460,7 +1460,7 @@ module MakeGAD(P: sig val prefix: string end) = struct
     MVar.guarded connector @@ fun connector ->
     let p = get_fdu_log_eval_path sysid tenantid nodeid fduid instanceid in
     let cb _ _ =
-      let%lwt r = func in
+      let%lwt r = func () in
       Lwt.return @@ Yaks.Value.StringValue r
     in
     let%lwt _ = Yaks.Workspace.register_eval p cb connector.ws in
@@ -1471,7 +1471,7 @@ module MakeGAD(P: sig val prefix: string end) = struct
     MVar.guarded connector @@ fun connector ->
     let p = get_fdu_ls_eval_path sysid tenantid nodeid fduid instanceid in
     let cb _ _ =
-      let%lwt r = func in
+      let%lwt r = func () in
       Lwt.return @@ Yaks.Value.StringValue r
     in
     let%lwt _ = Yaks.Workspace.register_eval p cb connector.ws in

--- a/fos-sdk/yaks_connector.ml
+++ b/fos-sdk/yaks_connector.ml
@@ -1492,6 +1492,34 @@ module MakeGAD(P: sig val prefix: string end) = struct
     let ls = List.append connector.evals [p] in
     MVar.return Lwt.return_unit {connector with evals = ls}
 
+   let remove_fdu_run_eval sysid tenantid nodeid fduid instanceid connector =
+    MVar.guarded connector @@ fun connector ->
+    let p = get_fdu_run_eval_path sysid tenantid nodeid fduid instanceid in
+    let%lwt _ = Yaks.Workspace.unregister_eval p connector.ws in
+    let ls = List.filter (fun e -> e != p ) connector.evals  in
+    MVar.return Lwt.return_unit {connector with evals = ls}
+
+  let remove_fdu_log_eval sysid tenantid nodeid fduid instanceid connector =
+    MVar.guarded connector @@ fun connector ->
+    let p = get_fdu_log_eval_path sysid tenantid nodeid fduid instanceid in
+    let%lwt _ = Yaks.Workspace.unregister_eval p connector.ws in
+    let ls = List.filter (fun e -> e != p ) connector.evals  in
+    MVar.return Lwt.return_unit {connector with evals = ls}
+
+  let remove_fdu_ls_eval sysid tenantid nodeid fduid instanceid connector =
+    MVar.guarded connector @@ fun connector ->
+    let p = get_fdu_ls_eval_path sysid tenantid nodeid fduid instanceid in
+   let%lwt _ = Yaks.Workspace.unregister_eval p connector.ws in
+    let ls = List.filter (fun e -> e != p ) connector.evals  in
+    MVar.return Lwt.return_unit {connector with evals = ls}
+
+  let remove_fdu_file_eval sysid tenantid nodeid fduid instanceid connector =
+    MVar.guarded connector @@ fun connector ->
+    let p = get_fdu_file_eval_path sysid tenantid nodeid fduid instanceid in
+    let%lwt _ = Yaks.Workspace.unregister_eval p connector.ws in
+    let ls = List.filter (fun e -> e != p ) connector.evals  in
+    MVar.return Lwt.return_unit {connector with evals = ls}
+
   (* FDU Eval *)
 
   let onboard_fdu_from_node sysid tenantid nodeid fdu_info connector =


### PR DESCRIPTION
Added functions, path generators and selector generators to enable the possibility of having blocking run for FDUs, recoved their log, list file inside the FDU directory (for native and ros2) and read file from the FDU directory (for native and ros2) 